### PR TITLE
Change tokenizer to use decimal for IR

### DIFF
--- a/grammar
+++ b/grammar
@@ -1,7 +1,13 @@
 # Lexer
 upname := [A-Z][_A-Za-z0-9]*
 name := [_a-z][_A-Za-z0-9]*
-number := [0-9]+(.[0-9]*)?
+number := <integer>(.<integer>?)?<expt>?
+integer := (0x<hex>|(0d)?<dec>|0o<oct>|0b<bin>)
+hex := [0-9A-Fa-f]+
+dec := [0-9]+
+oct := [0-7]+
+bin := [01]+
+expt := ([eEpP][+-]?<integer>)
 string := ".*?" | '.*?'
 
 # Parser

--- a/tokenizer.py
+++ b/tokenizer.py
@@ -1,5 +1,7 @@
 from acyctokens import Num, Ident, Op, Char, String, Keyword, EOF
 from acycexceptions import *
+from decimal import *
+getcontext().prec = 64
 
 
 class TokenBuffer:
@@ -105,7 +107,7 @@ def tokenize(string):
             else:
                 yield Ident(result, *pos)
         # Capture numbers
-        # number := [0-9]+(.[0-9]*)?
+        # number := (0(x|o|b))?[0-9]+(.[0-9]*)?
         elif buf.peek().isdigit():
             pos = buf.line, buf.col
             result = ""
@@ -119,7 +121,7 @@ def tokenize(string):
                     result += buf.peek()
                     buf.advance()
 
-            yield Num(float(result), *pos)
+            yield Num(Decimal(result), *pos)
         # Capture operators
         elif isop(buf.peek()):
             pos = buf.line, buf.col


### PR DESCRIPTION
Resolve #5
Update the definition for numeric literals in the grammar (preliminary for #7/#8)
- Note: Haven't changed the implementation yet
